### PR TITLE
Updates to read $DISPLAY from env before running

### DIFF
--- a/src/platforms/linux.js
+++ b/src/platforms/linux.js
@@ -2,7 +2,7 @@
 const exec = require('child_process').exec;
 const os = require('os');
 const linux = {};
-const DISPLAY = process.env.DISPLAY;
+const DISPLAY = process.env.DISPLAY || ':0';
 
 linux.sleep = () => {
     exec(`export DISPLAY=${DISPLAY}; xset dpms force suspend`);

--- a/src/platforms/linux.js
+++ b/src/platforms/linux.js
@@ -2,11 +2,13 @@
 const exec = require('child_process').exec;
 const os = require('os');
 const linux = {};
+const DISPLAY = process.env.DISPLAY;
+
 linux.sleep = () => {
-    exec('export DISPLAY=:0; xset dpms force suspend');
+    exec(`export DISPLAY=${DISPLAY}; xset dpms force suspend`);
 };
 linux.wake = () => {
-    exec('export DISPLAY=:0; xset dpms force on');
+    exec(`export DISPLAY=${DISPLAY}; xset dpms force on`);
 };
 linux.supported = () => {
     return os.platform() == 'linux';


### PR DESCRIPTION
...xset. Had an issue testing with my XPS9370 on multiple linux distros. Seems to work fine on desktops tho, so it may be specific to certain laptops. This change seems to work for most machines I've tested on. Probably doesn't take into account setups where the number of monitors changes.